### PR TITLE
fix: invalidate pending async parented-widget setup on hide

### DIFF
--- a/source/extensions/omni.kit.xr.samples.usd_scene_ui/omni/kit/xr/samples/usd_scene_ui/widget_gallery_example.py
+++ b/source/extensions/omni.kit.xr.samples.usd_scene_ui/omni/kit/xr/samples/usd_scene_ui/widget_gallery_example.py
@@ -101,6 +101,7 @@ class WidgetGalleryExample:
         self._parented_widget_container: Optional[UiContainer] = None
         self._rotatable_text_widget_container: Optional[UiContainer] = None
         self._rotatable_slider_widget_container: Optional[UiContainer] = None
+        self._show_generation = 0
 
         self._example_menu_item = XREditorMenuToggleItem(
             ext_id, WIDGET_GALLERY_EXAMPLE_MENU_PATH, self._toggle_example, value=False
@@ -123,6 +124,8 @@ class WidgetGalleryExample:
             self._hide()
 
     def _hide(self):
+        self._show_generation += 1
+
         if self._static_text_widget_container:
             self._static_text_widget_container.root.clear()
             self._static_text_widget_container = None
@@ -148,6 +151,8 @@ class WidgetGalleryExample:
             self._rotatable_slider_widget_container = None
 
     def _show(self):
+        self._show_generation += 1
+
         # 1. Place static "Simple Text" at the origin.
         static_text_widget_component = WidgetComponent(SimpleTextWidget, width=400, height=200)
 
@@ -187,9 +192,14 @@ class WidgetGalleryExample:
             "CreateMeshPrimWithDefaultXform", prim_type="Cube", object_origin=[400, 0, 0], select_new_prim=False
         )
 
+        current_generation = self._show_generation
+
         async def __wait_one_frame():
             # Wait one frame after creating the Cube as it is not ready.
             await omni.kit.app.get_app().next_update_async()
+
+            if self._show_generation != current_generation:
+                return
 
             parented_widget_component = WidgetComponent(
                 SimpleTextWidget, width=400, height=200, resolution_scale=2, widget_args=["Parented to Cube"]


### PR DESCRIPTION
This PR addresses the following issue in `source/extensions/omni.kit.xr.samples.usd_scene_ui/omni/kit/xr/samples/usd_scene_ui/widget_gallery_example.py`: invalidate pending async parented-widget setup on hide.

## Changes
- `source/extensions/omni.kit.xr.samples.usd_scene_ui/omni/kit/xr/samples/usd_scene_ui/widget_gallery_example.py`: invalidate pending async parented-widget setup on hide.

## Details
```diff
--- a/source/extensions/omni.kit.xr.samples.usd_scene_ui/omni/kit/xr/samples/usd_scene_ui/widget_gallery_example.py
+++ b/source/extensions/omni.kit.xr.samples.usd_scene_ui/omni/kit/xr/samples/usd_scene_ui/widget_gallery_example.py
@@ -44,6 +44,7 @@ class WidgetGalleryExample:
         self._parented_widget_container: Optional[UiContainer] = None
         self._rotatable_text_widget_container: Optional[UiContainer] = None
         self._rotatable_slider_widget_container: Optional[UiContainer] = None
+        self._show_generation = 0
 
         self._example_menu_item = XREditorMenuToggleItem(
             ext_id, WIDGET_GALLERY_EXAMPLE_MENU_PATH, self._toggle_example, value=False
@@ -63,6 +64,8 @@ class WidgetGalleryExample:
             self._rotatable_slider_widget_container = None
 
     def _hide(self):
+        self._show_generation += 1
+
         if self._static_text_widget_container:
             self._static_text_widget_container.root.clear()
             self._static_text_widget_container = None
@@ -73,6 +76,8 @@ class WidgetGalleryExample:
             self._counting_widget_container = None
 
     def _show(self):
+        self._show_generation += 1
+
         # 1. Place static "Simple Text" at the origin.
         static_text_widget_component = WidgetComponent(SimpleTextWidget, width=400, height=200)
 
@@ -104,10 +109,15 @@ class WidgetGalleryExample:
             "CreateMeshPrimWithDefaultXform", prim_type="Cube", object_origin=[400, 0, 0], select_new_prim=False
         )
 
+        current_generation = self._show_generation
+
         async def __wait_one_frame():
             # Wait one frame after creating the Cube as it is not ready.
             await omni.kit.app.get_app().next_update_async()
 
+            if self._show_generation != current_generation:
+                return
+
             parented_widget_component = WidgetComponent(
                 SimpleTextWidget, width=400, height=200, resolution_scale=2, widget_args=["Parented to Cube"]
             )
```

## Tests
- `source/extensions/omni.kit.xr.samples.usd_scene_ui/tests/test_widget_gallery_async.py`

```diff
--- /dev/null
+++ b/source/extensions/omni.kit.xr.samples.usd_scene_ui/tests/test_widget_gallery_async.py
@@ -0,0 +1,48 @@
+import asyncio
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+sys.modules["omni"] = MagicMock()
+sys.modules["omni.kit"] = MagicMock()
+sys.modules["omni.kit.app"] = MagicMock()
+sys.modules["omni.kit.commands"] = MagicMock()
+sys.modules["omni.ui"] = MagicMock()
+sys.modules["omni.kit.xr.core"] = MagicMock()
+sys.modules["omni.kit.xr.scene_view.utils"] = MagicMock()
+sys.modules["omni.kit.xr.scene_view.utils.spatial_source"] = MagicMock()
+sys.modules["pxr"] = MagicMock()
+sys.modules["pxr.Gf"] = MagicMock()
+
+from omni.kit.xr.samples.usd_scene_ui.widget_gallery_example import WidgetGalleryExample
+
+
+class TestWidgetGalleryAsync(unittest.TestCase):
+    def test_hide_prevents_stale_parented_container(self):
+        """Toggling off before the async setup finishes must not leave a container."""
+        example = WidgetGalleryExample("ext_id")
+
+        async def immediate():
+            return
+
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        try:
+            with patch("omni.kit.app.get_app") as mock_app:
+                mock_app.return_value.next_update_async = immediate
+                example._show()
+                example._hide()
+
+                pending = [t for t in asyncio.all_tasks(loop) if not t.done()]
+                if pending:
+                    loop.run_until_complete(asyncio.gather(*pending, return_exceptions=True))
+
+            self.assertIsNone(example._parented_widget_container)
+        finally:
+            loop.close()
+            asyncio.set_event_loop(None)
+
+
+if __name__ == "__main__":
+    unittest.main()
```