### PR TITLE
fix: express initial 45-degree rotation in radians

### DIFF
--- a/source/extensions/omni.kit.xr.samples.usd_scene_ui/omni/kit/xr/samples/usd_scene_ui/widget_gallery_example.py
+++ b/source/extensions/omni.kit.xr.samples.usd_scene_ui/omni/kit/xr/samples/usd_scene_ui/widget_gallery_example.py
@@ -212,7 +212,7 @@ class WidgetGalleryExample:
             SimpleTextWidget, width=400, height=200, resolution_scale=2, widget_args=["Slide to rotate"]
         )
 
-        self._rotation_source = SpatialSource.new_rotation_source(Gf.Vec3d(0, 45, 0))
+        self._rotation_source = SpatialSource.new_rotation_source(Gf.Vec3d(0, math.radians(45), 0))
         self._rotatable_text_widget_container = UiContainer(
             rotatable_text_widget_component,
             space_stack=[SpatialSource.new_translation_source(Gf.Vec3d(-600, 350, 0)), self._rotation_source],


### PR DESCRIPTION
This PR addresses the following issue in `source/extensions/omni.kit.xr.samples.usd_scene_ui/omni/kit/xr/samples/usd_scene_ui/widget_gallery_example.py`: express initial 45-degree rotation in radians.

## Changes
- `source/extensions/omni.kit.xr.samples.usd_scene_ui/omni/kit/xr/samples/usd_scene_ui/widget_gallery_example.py`: express initial 45-degree rotation in radians.

## Details
```diff
--- a/source/extensions/omni.kit.xr.samples.usd_scene_ui/omni/kit/xr/samples/usd_scene_ui/widget_gallery_example.py
+++ b/source/extensions/omni.kit.xr.samples.usd_scene_ui/omni/kit/xr/samples/usd_scene_ui/widget_gallery_example.py
@@ -1,1 +1,1 @@
-        self._rotation_source = SpatialSource.new_rotation_source(Gf.Vec3d(0, 45, 0))
+        self._rotation_source = SpatialSource.new_rotation_source(Gf.Vec3d(0, math.radians(45), 0))
```

## Tests
- `source/extensions/omni.kit.xr.samples.usd_scene_ui/tests/test_widget_gallery_rotation.py`

```diff
--- /dev/null
+++ b/source/extensions/omni.kit.xr.samples.usd_scene_ui/tests/test_widget_gallery_rotation.py
@@ -0,0 +1,17 @@
+import pathlib
+import unittest
+
+SOURCE_FILE = pathlib.Path(__file__).parent.parent / "omni/kit/xr/samples/usd_scene_ui/widget_gallery_example.py"
+
+
+class TestWidgetGalleryRotation(unittest.TestCase):
+    def test_static_rotation_uses_radians(self):
+        """The initial 45-degree yaw must be in radians, matching the dynamic path."""
+        source = SOURCE_FILE.read_text()
+        self.assertNotIn("SpatialSource.new_rotation_source(Gf.Vec3d(0, 45, 0))", source)
+        self.assertIn("SpatialSource.new_rotation_source(Gf.Vec3d(0, math.radians(45), 0))", source)
+
+
+if __name__ == "__main__":
+    unittest.main()
```