### PR TITLE
fix: clear stage event delegate reference after unsubscribing

### DIFF
--- a/source/extensions/omni.kit.xr.samples.usd_scene_ui/omni/kit/xr/samples/usd_scene_ui/prim_transform_example.py
+++ b/source/extensions/omni.kit.xr.samples.usd_scene_ui/omni/kit/xr/samples/usd_scene_ui/prim_transform_example.py
@@ -161,6 +161,7 @@ class PrimTransformExample:
 
         if self._stage_event_delegate:
             self._stage_event_delegate.unsubscribe()
+            self._stage_event_delegate = None
 
         if self._widget_container:
             self._widget_container.root.clear()

--- a/source/extensions/omni.kit.xr.samples.usd_scene_ui/tests/test_prim_transform_example.py
+++ b/source/extensions/omni.kit.xr.samples.usd_scene_ui/tests/test_prim_transform_example.py
@@ -1,0 +1,42 @@
+import sys
+import unittest
+from unittest.mock import MagicMock
+
+sys.modules["omni"] = MagicMock()
+sys.modules["omni.kit"] = MagicMock()
+sys.modules["omni.kit.app"] = MagicMock()
+sys.modules["omni.usd"] = MagicMock()
+sys.modules["carb"] = MagicMock()
+sys.modules["carb.events"] = MagicMock()
+sys.modules["omni.ui"] = MagicMock()
+sys.modules["omni.kit.property.transform.scripts.transform_widget"] = MagicMock()
+sys.modules["omni.kit.property.usd.prim_selection_payload"] = MagicMock()
+sys.modules["omni.kit.xr.core"] = MagicMock()
+sys.modules["omni.kit.xr.scene_view.utils"] = MagicMock()
+sys.modules["omni.kit.xr.scene_view.utils.spatial_source"] = MagicMock()
+sys.modules["pxr"] = MagicMock()
+sys.modules["pxr.Gf"] = MagicMock()
+sys.modules["pxr.Sdf"] = MagicMock()
+sys.modules["pxr.Usd"] = MagicMock()
+sys.modules["pxr.UsdGeom"] = MagicMock()
+
+from omni.kit.xr.samples.usd_scene_ui.prim_transform_example import PrimTransformExample
+
+
+class TestPrimTransformExample(unittest.TestCase):
+    def test_hide_clears_stage_event_delegate(self):
+        """_hide must reset the delegate reference after unsubscribing."""
+        example = PrimTransformExample("ext_id")
+        mock_delegate = MagicMock()
+        example._stage_event_delegate = mock_delegate
+        example._widget_container = None
+        example._usd_context = None
+
+        example._hide()
+
+        mock_delegate.unsubscribe.assert_called_once()
+        self.assertIsNone(example._stage_event_delegate)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR addresses the following issue in `source/extensions/omni.kit.xr.samples.usd_scene_ui/omni/kit/xr/samples/usd_scene_ui/prim_transform_example.py`: clear stage event delegate reference after unsubscribing.

## Changes
- `source/extensions/omni.kit.xr.samples.usd_scene_ui/omni/kit/xr/samples/usd_scene_ui/prim_transform_example.py`: clear stage event delegate reference after unsubscribing.

## Details
```diff
--- a/source/extensions/omni.kit.xr.samples.usd_scene_ui/omni/kit/xr/samples/usd_scene_ui/prim_transform_example.py
+++ b/source/extensions/omni.kit.xr.samples.usd_scene_ui/omni/kit/xr/samples/usd_scene_ui/prim_transform_example.py
@@ -1,9 +1,10 @@
-    def _hide(self):
-        self._app_update_sub = None
-
-        if self._stage_event_delegate:
-            self._stage_event_delegate.unsubscribe()
-
-        if self._widget_container:
-            self._widget_container.root.clear()
-            self._widget_container = None
+    def _hide(self):
+        self._app_update_sub = None
+
+        if self._stage_event_delegate:
+            self._stage_event_delegate.unsubscribe()
+            self._stage_event_delegate = None
+
+        if self._widget_container:
+            self._widget_container.root.clear()
+            self._widget_container = None
```

## Tests
- `source/extensions/omni.kit.xr.samples.usd_scene_ui/tests/test_prim_transform_example.py`

```diff
--- /dev/null
+++ b/source/extensions/omni.kit.xr.samples.usd_scene_ui/tests/test_prim_transform_example.py
@@ -0,0 +1,42 @@
+import sys
+import unittest
+from unittest.mock import MagicMock
+
+sys.modules["omni"] = MagicMock()
+sys.modules["omni.kit"] = MagicMock()
+sys.modules["omni.kit.app"] = MagicMock()
+sys.modules["omni.usd"] = MagicMock()
+sys.modules["carb"] = MagicMock()
+sys.modules["carb.events"] = MagicMock()
+sys.modules["omni.ui"] = MagicMock()
+sys.modules["omni.kit.property.transform.scripts.transform_widget"] = MagicMock()
+sys.modules["omni.kit.property.usd.prim_selection_payload"] = MagicMock()
+sys.modules["omni.kit.xr.core"] = MagicMock()
+sys.modules["omni.kit.xr.scene_view.utils"] = MagicMock()
+sys.modules["omni.kit.xr.scene_view.utils.spatial_source"] = MagicMock()
+sys.modules["pxr"] = MagicMock()
+sys.modules["pxr.Gf"] = MagicMock()
+sys.modules["pxr.Sdf"] = MagicMock()
+sys.modules["pxr.Usd"] = MagicMock()
+sys.modules["pxr.UsdGeom"] = MagicMock()
+
+from omni.kit.xr.samples.usd_scene_ui.prim_transform_example import PrimTransformExample
+
+
+class TestPrimTransformExample(unittest.TestCase):
+    def test_hide_clears_stage_event_delegate(self):
+        """_hide must reset the delegate reference after unsubscribing."""
+        example = PrimTransformExample("ext_id")
+        mock_delegate = MagicMock()
+        example._stage_event_delegate = mock_delegate
+        example._widget_container = None
+        example._usd_context = None
+
+        example._hide()
+
+        mock_delegate.unsubscribe.assert_called_once()
+        self.assertIsNone(example._stage_event_delegate)
+
+
+if __name__ == "__main__":
+    unittest.main()
```