### PR TITLE
fix: use FloatSlider for SimpleFloatModel position sliders

### DIFF
--- a/source/extensions/omni.kit.xr.samples.usd_scene_ui/omni/kit/xr/samples/usd_scene_ui/prim_maker_example.py
+++ b/source/extensions/omni.kit.xr.samples.usd_scene_ui/omni/kit/xr/samples/usd_scene_ui/prim_maker_example.py
@@ -79,13 +79,13 @@ class PrimMakerExampleUI(ui.Widget):
                             ui.Label("Position:")
                             with ui.HStack(spacing=4):
                                 ui.Label("X", width=0)
-                                ui.IntSlider(self._x_slider_model, min=-1000, max=1000)
+                                ui.FloatSlider(self._x_slider_model, min=-1000, max=1000)
                             with ui.HStack(spacing=4):
                                 ui.Label("Y", width=0)
-                                ui.IntSlider(self._y_slider_model, min=-1000, max=1000)
+                                ui.FloatSlider(self._y_slider_model, min=-1000, max=1000)
                             with ui.HStack(spacing=4):
                                 ui.Label("Z", width=0)
-                                ui.IntSlider(self._z_slider_model, min=-1000, max=1000)
+                                ui.FloatSlider(self._z_slider_model, min=-1000, max=1000)
                             ui.Spacer(height=2)
                             with ui.VStack(style={"margin": 1}):
                                 with ui.HStack():


### PR DESCRIPTION
This PR addresses the following issue in `source/extensions/omni.kit.xr.samples.usd_scene_ui/omni/kit/xr/samples/usd_scene_ui/prim_maker_example.py`: use FloatSlider for SimpleFloatModel position sliders.

## Changes
- `source/extensions/omni.kit.xr.samples.usd_scene_ui/omni/kit/xr/samples/usd_scene_ui/prim_maker_example.py`: use FloatSlider for SimpleFloatModel position sliders.

## Details
```diff
--- a/source/extensions/omni.kit.xr.samples.usd_scene_ui/omni/kit/xr/samples/usd_scene_ui/prim_maker_example.py
+++ b/source/extensions/omni.kit.xr.samples.usd_scene_ui/omni/kit/xr/samples/usd_scene_ui/prim_maker_example.py
@@ -1,9 +1,9 @@
-                            with ui.HStack(spacing=4):
-                                ui.Label("X", width=0)
-                                ui.IntSlider(self._x_slider_model, min=-1000, max=1000)
-                            with ui.HStack(spacing=4):
-                                ui.Label("Y", width=0)
-                                ui.IntSlider(self._y_slider_model, min=-1000, max=1000)
-                            with ui.HStack(spacing=4):
-                                ui.Label("Z", width=0)
-                                ui.IntSlider(self._z_slider_model, min=-1000, max=1000)
+                            with ui.HStack(spacing=4):
+                                ui.Label("X", width=0)
+                                ui.FloatSlider(self._x_slider_model, min=-1000, max=1000)
+                            with ui.HStack(spacing=4):
+                                ui.Label("Y", width=0)
+                                ui.FloatSlider(self._y_slider_model, min=-1000, max=1000)
+                            with ui.HStack(spacing=4):
+                                ui.Label("Z", width=0)
+                                ui.FloatSlider(self._z_slider_model, min=-1000, max=1000)
```

## Tests
- `source/extensions/omni.kit.xr.samples.usd_scene_ui/tests/test_prim_maker_example.py`

```diff
--- /dev/null
+++ b/source/extensions/omni.kit.xr.samples.usd_scene_ui/tests/test_prim_maker_example.py
@@ -0,0 +1,19 @@
+import pathlib
+import unittest
+
+SOURCE_FILE = pathlib.Path(__file__).parent.parent / "omni/kit/xr/samples/usd_scene_ui/prim_maker_example.py"
+
+
+class TestPrimMakerExample(unittest.TestCase):
+    def test_position_sliders_use_float_slider_with_float_model(self):
+        """Float models must drive FloatSlider controls, not IntSlider."""
+        source = SOURCE_FILE.read_text()
+        for axis in ("x", "y", "z"):
+            self.assertIn(f"ui.FloatSlider(self._{axis}_slider_model", source)
+            self.assertNotIn(f"ui.IntSlider(self._{axis}_slider_model", source)
+
+
+if __name__ == "__main__":
+    unittest.main()
```