### PR TITLE
fix: prim_maker example is not destroyed on extension shutdown

### DIFF
--- a/source/extensions/omni.kit.xr.samples.usd_scene_ui/omni/kit/xr/samples/usd_scene_ui/extension.py
+++ b/source/extensions/omni.kit.xr.samples.usd_scene_ui/omni/kit/xr/samples/usd_scene_ui/extension.py
@@ -59,7 +59,9 @@ class XRSceneViewExampleExtension(omni.ext.IExt):
             self._prim_transform_example.destroy()
             self._prim_transform_example = None
 
-        self._prim_maker_example = None
+        if self._prim_maker_example:
+            self._prim_maker_example.destroy()
+            self._prim_maker_example = None
 
         if self._ag_no_code_ui_example:
             self._ag_no_code_ui_example.destroy()

--- a/source/extensions/omni.kit.xr.samples.usd_scene_ui/tests/test_extension_shutdown.py
+++ b/source/extensions/omni.kit.xr.samples.usd_scene_ui/tests/test_extension_shutdown.py
@@ -1,0 +1,31 @@
+import importlib
+import inspect
+import unittest
+from unittest.mock import MagicMock
+
+
+class TestExtensionShutdown(unittest.TestCase):
+    def test_prim_maker_example_is_destroyed(self):
+        module = importlib.import_module("omni.kit.xr.samples.usd_scene_ui.extension")
+        ext_classes = [
+            obj
+            for obj in module.__dict__.values()
+            if inspect.isclass(obj)
+            and obj.__module__ == module.__name__
+            and hasattr(obj, "on_shutdown")
+        ]
+        self.assertTrue(ext_classes, "extension class with on_shutdown not found")
+
+        ext = ext_classes[0]()
+        ext._prim_transform_example = None
+        ext._prim_maker_example = MagicMock()
+        ext._ag_no_code_ui_example = None
+
+        ext.on_shutdown()
+
+        ext._prim_maker_example.destroy.assert_called_once()
+        self.assertIsNone(ext._prim_maker_example)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR addresses the following issue in `source/extensions/omni.kit.xr.samples.usd_scene_ui/omni/kit/xr/samples/usd_scene_ui/extension.py`: prim_maker example is not destroyed on extension shutdown.

## Changes
- `source/extensions/omni.kit.xr.samples.usd_scene_ui/omni/kit/xr/samples/usd_scene_ui/extension.py`: prim_maker example is not destroyed on extension shutdown.

## Details
See the Files changed tab for the exact diff.

## Tests
- `source/extensions/omni.kit.xr.samples.usd_scene_ui/tests/test_extension_shutdown.py`