### PR TITLE
fix: actiongraph example uses omni.usd without importing it

### DIFF
--- a/source/extensions/omni.kit.xr.samples.usd_scene_ui/omni/kit/xr/samples/usd_scene_ui/actiongraph_no_code_ui_example.py
+++ b/source/extensions/omni.kit.xr.samples.usd_scene_ui/omni/kit/xr/samples/usd_scene_ui/actiongraph_no_code_ui_example.py
@@ -13,6 +13,7 @@ import asyncio
 import carb.events
 import omni.kit
 import omni.kit.window.file
+import omni.usd
 from omni.kit.xr.core import XREditorMenuToggleItem
 
 PRIM_TRANSFORM_EXAMPLE_MENU_PATH: str = "Examples/(XR UI) Action Graph No Code UI"

--- a/source/extensions/omni.kit.xr.samples.usd_scene_ui/tests/test_actiongraph_import.py
+++ b/source/extensions/omni.kit.xr.samples.usd_scene_ui/tests/test_actiongraph_import.py
@@ -1,0 +1,21 @@
+import ast
+import os
+import unittest
+
+
+class TestActionGraphImport(unittest.TestCase):
+    def test_omni_usd_is_imported(self):
+        module_path = os.path.join(
+            os.path.dirname(__file__), "..", "omni", "kit", "xr", "samples", "usd_scene_ui",
+            "actiongraph_no_code_ui_example.py",
+        )
+        with open(module_path, "r", encoding="utf-8") as f:
+            source = f.read()
+        imports = {
+            alias.name
+            for node in ast.walk(ast.parse(source))
+            if isinstance(node, (ast.Import, ast.ImportFrom))
+            for alias in node.names
+        }
+        self.assertIn("omni.usd", imports)
+


### PR DESCRIPTION
This PR addresses the following issue in `source/extensions/omni.kit.xr.samples.usd_scene_ui/omni/kit/xr/samples/usd_scene_ui/actiongraph_no_code_ui_example.py`: actiongraph example uses omni.usd without importing it.

## Changes
- `source/extensions/omni.kit.xr.samples.usd_scene_ui/omni/kit/xr/samples/usd_scene_ui/actiongraph_no_code_ui_example.py`: actiongraph example uses omni.usd without importing it.

## Details
See the Files changed tab for the exact diff.

## Tests
- `source/extensions/omni.kit.xr.samples.usd_scene_ui/tests/test_actiongraph_import.py`