### PR TITLE
fix: docs index.rst references old python module name

### DIFF
--- a/source/extensions/omni.kit.xr.samples.usd_scene_ui/docs/index.rst
+++ b/source/extensions/omni.kit.xr.samples.usd_scene_ui/docs/index.rst
@@ -1,5 +1,5 @@
-omni.example.usd_scene_ui
-#############################
+omni.kit.xr.samples.usd_scene_ui
+################################
 
 Example creating a USD Scene UI
 
@@ -11,7 +11,7 @@ Example creating a USD Scene UI
    CHANGELOG
 
 
-.. automodule::"omni.example.usd_scene_ui"
+.. automodule:: omni.kit.xr.samples.usd_scene_ui
     :platform: Windows-x86_64, Linux-x86_64
     :members:
     :undoc-members:


### PR DESCRIPTION
This PR addresses the following issue in `source/extensions/omni.kit.xr.samples.usd_scene_ui/docs/index.rst`: docs index.rst references old python module name.

## Changes
- `source/extensions/omni.kit.xr.samples.usd_scene_ui/docs/index.rst`: docs index.rst references old python module name.

## Details
See the Files changed tab for the exact diff.

## Tests
- `source/extensions/omni.kit.xr.samples.usd_scene_ui/tests/test_docs_module_name.py`