### PR TITLE
fix: clang-format option key has extra space before colon

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -7,7 +7,7 @@ AlignTrailingComments: false
 AllowAllParametersOfDeclarationOnNextLine: true
 AllowShortFunctionsOnASingleLine: false
 AllowShortIfStatementsOnASingleLine: false
-AllowShortCaseLabelsOnASingleLine : false
+AllowShortCaseLabelsOnASingleLine: false
 AllowShortLoopsOnASingleLine: false
 AlwaysBreakAfterDefinitionReturnType: false
 AlwaysBreakBeforeMultilineStrings: true

--- a/tests/test_clang_format.py
+++ b/tests/test_clang_format.py
@@ -1,0 +1,18 @@
+import pathlib
+
+
+def test_clang_format_top_level_keys_no_trailing_space():
+    repo = pathlib.Path(__file__).resolve().parent.parent
+    clang_format = repo / '.clang-format'
+    assert clang_format.exists()
+
+    for line in clang_format.read_text().splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith('#'):
+            continue
+        # Top-level keys are not indented; indented lines belong to lists like IncludeCategories.
+        if not line.startswith(' '):
+            key, _sep = line.split(':', 1)
+            assert not key.endswith(' '), (
+                f"Top-level option key has trailing space before colon: {key!r}"
+            )


### PR DESCRIPTION
This PR addresses the following issue in `.clang-format`: clang-format option key has extra space before colon.

## Changes
- `.clang-format`: clang-format option key has extra space before colon.

## Details
```diff
--- a/.clang-format
+++ b/.clang-format
@@ -1,1 +1,1 @@
-AllowShortCaseLabelsOnASingleLine : false
+AllowShortCaseLabelsOnASingleLine: false
```

## Tests
- `tests/test_clang_format.py`

```diff
--- /dev/null
+++ b/tests/test_clang_format.py
@@ -0,0 +1,18 @@
+import pathlib
+
+
+def test_clang_format_top_level_keys_no_trailing_space():
+    repo = pathlib.Path(__file__).resolve().parent.parent
+    clang_format = repo / '.clang-format'
+    assert clang_format.exists()
+
+    for line in clang_format.read_text().splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith('#'):
+            continue
+        # Top-level keys are not indented; indented lines belong to lists like IncludeCategories.
+        if not line.startswith(' '):
+            key, _sep = line.split(':', 1)
+            assert not key.endswith(' '), (
+                f"Top-level option key has trailing space before colon: {key!r}"
+            )
```